### PR TITLE
Fixed floating point transmit issue

### DIFF
--- a/OMMoCoBus/OMMoCoBus.cpp
+++ b/OMMoCoBus/OMMoCoBus.cpp
@@ -698,16 +698,39 @@ void OMMoCoBus::write( int p_dat ) {
 
 /** Write Data to Bus
 
+Writes packet data to the bus, should only ever be used after sendPacketHeader().
+
+The
+
+*/
+
+void OMMoCoBus::write(unsigned long p_dat) {
+
+	write((uint8_t)(p_dat >> 24));
+	write((uint8_t)(p_dat >> 16));
+	write((uint8_t)(p_dat >> 8));
+	write((uint8_t)p_dat);
+
+}
+
+/** Write Data to Bus
+
  Writes packet data to the bus, should only ever be used after sendPacketHeader().
+
+ The 
 
  */
 
-void OMMoCoBus::write( unsigned long p_dat ) {
+void OMMoCoBus::write( float p_dat ) {
 
-    write( (uint8_t) (p_dat >> 24) );
-    write( (uint8_t) (p_dat >> 16) );
-    write( (uint8_t) (p_dat >> 8) );
-    write( (uint8_t) p_dat);
+	// Convert float to fixed point with two decimal places stored as an unsigned long.
+	// This value must be divided by 100 on the receiving side to get the intended float.
+	unsigned long fixed_point = p_dat * 100; 
+
+	write( (uint8_t) (fixed_point >> 24));
+	write( (uint8_t) (fixed_point >> 16));
+	write( (uint8_t) (fixed_point >> 8));
+	write( (uint8_t) fixed_point);
 
 }
 

--- a/OMMoCoBus/OMMoCoBus.h
+++ b/OMMoCoBus/OMMoCoBus.h
@@ -225,7 +225,9 @@ protected:
 	void write(unsigned int p_dat);
 	void write(int p_dat);
 	void write(unsigned long p_dat);
+	void write(float p_dat);
 	void write(long p_dat);
+	
 
 private:
 

--- a/OMMoCoNode/OMMoCoNode.cpp
+++ b/OMMoCoNode/OMMoCoNode.cpp
@@ -154,9 +154,10 @@ void OMMoCoNode::response(bool p_stat, unsigned long p_resp) {
 
 void OMMoCoNode::response(bool p_stat, float p_resp) {
 		// 5 bytes returned to master (type + data size)
+	
 	sendPacketHeader(OM_SER_MASTER, p_stat, 5);
 	this->write((uint8_t) R_FLOAT);
-	this->write((unsigned long) p_resp);
+	this->write(p_resp);
 }
 
 /** Send Response Data to Master


### PR DESCRIPTION
Floating point values sent in response to a master request are now sent
as a fixed point value encoded as an unsigned long integer. The
transmitted value must be divided by 100 by the master to get the
correct decimal value.
