### PR TITLE
Changes to support later verisions of avr-gcc

### DIFF
--- a/OMMenuMgr/OMMenuMgr.cpp
+++ b/OMMenuMgr/OMMenuMgr.cpp
@@ -48,11 +48,11 @@
 
  */
 
-OMMenuMgr::OMMenuMgr(OMMenuItem* c_first, uint8_t c_type) {
+OMMenuMgr::OMMenuMgr(const OMMenuItem* c_first, uint8_t c_type) {
 
     m_inputType  = c_type;
-    m_curParent  = c_first;
-    m_rootItem   = c_first;
+    m_curParent  = const_cast<OMMenuItem*>(c_first);
+    m_rootItem   = const_cast<OMMenuItem*>(c_first);
     m_inEdit     = false;
     m_enable     = true;
     m_menuActive = false;

--- a/OMMenuMgr/OMMenuMgr.h
+++ b/OMMenuMgr/OMMenuMgr.h
@@ -74,16 +74,22 @@
 
 
 
-#define MENU_ITEM           PROGMEM OMMenuItem
-#define MENU_LIST           PROGMEM OMMenuItem*
-#define MENU_VALUE          PROGMEM OMMenuValue
+//#define MENU_ITEM           PROGMEM OMMenuItem
+//#define MENU_LIST           PROGMEM OMMenuItem*
+//#define MENU_VALUE          PROGMEM OMMenuValue
+#define MENU_ITEM           OMMenuItem const PROGMEM
+#define MENU_LIST           const OMMenuItem* const PROGMEM
+#define MENU_VALUE          OMMenuValue const PROGMEM
 #define MENU_FLAG           PROGMEM OMMenuValueFlag
-#define MENU_SELECT_ITEM    PROGMEM OMMenuSelectListItem
-#define MENU_SELECT_LIST    PROGMEM OMMenuSelectListItem*
-#define MENU_SELECT         PROGMEM OMMenuSelectValue
+//#define MENU_SELECT_ITEM    PROGMEM OMMenuSelectListItem
+//#define MENU_SELECT_LIST    PROGMEM OMMenuSelectListItem*
+//#define MENU_SELECT         PROGMEM OMMenuSelectValue
+#define MENU_SELECT_ITEM    OMMenuSelectListItem const PROGMEM
+#define MENU_SELECT_LIST    const OMMenuSelectListItem* const PROGMEM
+#define MENU_SELECT         OMMenuSelectValue const PROGMEM
 #define MENU_SELECT_SIZE(x) sizeof(x) / sizeof(OMMenuSelectListItem*)
 #define MENU_SIZE(x)        sizeof(x) / sizeof(OMMenuItem*)
-#define MENU_TARGET(x)      reinterpret_cast<void*>(x)
+#define MENU_TARGET(x)      reinterpret_cast<const void*>(x)
 
 
 /** Select-Type Item
@@ -92,7 +98,7 @@
  */
 struct OMMenuSelectListItem {
     uint8_t   value;
-    prog_char label[OM_MENU_LBLLEN];
+    const char label[OM_MENU_LBLLEN];
 };
 
 
@@ -105,7 +111,7 @@ struct OMMenuSelectValue {
     uint8_t* targetValue;
     uint8_t listCount;
         /** Void Pointer to list of select items (OMMenuSelectListItem**) */
-    void* list;
+    const void* list;
 };
 
 
@@ -138,10 +144,10 @@ struct OMMenuValueFlag {
  */
 
 struct OMMenuItem {
-    prog_char     label[OM_MENU_COLS];
+    const char    label[OM_MENU_COLS];
     uint8_t       type;
     uint8_t       targetCount;
-    void*         target;
+    const void*   target;
 };
 
 
@@ -157,7 +163,7 @@ struct OMMenuValue {
     uint8_t type;
     long    max;
     long    min;
-    void*   targetValue;
+    const void*   targetValue;
     int     eepromLoc;
 };
 
@@ -912,7 +918,7 @@ class OMMenuMgr {
 
 public:
 
-    OMMenuMgr(OMMenuItem* c_first, uint8_t c_type = MENU_ANALOG);
+    OMMenuMgr(const OMMenuItem* c_first, uint8_t c_type = MENU_ANALOG);
 
     void setAnalogButtonPin(uint8_t p_pin, const int p_values[5][2], int p_thresh);
     void setDigitalButtonPins(const int p_pins[5][2]);


### PR DESCRIPTION
Incorporates updates from @avr39-ripe. fixes DynamicPerception/OMLibraries#6
adding a few additional changes so the example compiles with no changes.
I tested this with my own menu system on avr-gcc 4.8.1 from Arduino 1.6.5
